### PR TITLE
FIX: Cavity-pass and find_orbit6

### DIFF
--- a/src/Track.jl
+++ b/src/Track.jl
@@ -25,16 +25,23 @@ export Constants,
 using PrecompileTools
 
 @setup_workload begin
+    v::Vector{Float64} = rand(Float64, 6) * 1e-6
+    poly::Vector{Float64} = zeros(Float64, 3)
     @compile_workload begin
-        v::Vector{Float64} = rand(Float64, 6) * 1e-6
         p = Pos(v)
-        lattice = Element[Element("dummy_element")]
+        marker = Elements.marker("marker")
+        dip = Elements.rbend("dip", 0.01, 0.01, 0.0, 0.0, 0.0, 0.0, 0.0, copy(poly), copy(poly), -999.0, -999.0, 1)
+        quad = Elements.quadrupole("quad", 0.02, 0.0, nr_steps=1)
+        sext = Elements.sextupole("sext", 0.02, 0.0, nr_steps=1)
+        cav = Elements.rfcavity("cav", 0.0, 1.0, 0.0, 0.0)
+        drift = Elements.drift("drift", 0.0)
+        lattice = Element[drift, marker, dip, quad, sext, cav]
         m = Accelerator(3e9)
         m.lattice = lattice
         m.radiation_state = Auxiliary.full
         m.cavity_state = Auxiliary.on
         m.vchamber_state = Auxiliary.on
-        pf, st, lf = ring_pass(m, p, 1)
+        pf, st, lf = ring_pass(m, p, 1, turn_by_turn=true)
         find_orbit4(m)
         find_orbit6(m)
     end

--- a/src/modules/Elements/elementsModule.jl
+++ b/src/modules/Elements/elementsModule.jl
@@ -102,12 +102,13 @@ function sextupole(fam_name::String, length::Float64, S::Float64; nr_steps::Int=
     return element
 end
 
-function rfcavity(fam_name::String, frequency::Float64, voltage::Float64, phase_lag::Float64)  
+function rfcavity(fam_name::String, frequency::Float64, voltage::Float64, phase_lag::Float64, length::Float64=0.0)  
     element = Element(fam_name)
     element.pass_method = pm_cavity_pass
     element.frequency = frequency
     element.voltage = voltage
     element.phase_lag = phase_lag
+    element.length = length
     return element
 end
 

--- a/src/modules/Orbit/FindOrbit.jl
+++ b/src/modules/Orbit/FindOrbit.jl
@@ -8,7 +8,7 @@ using LinearAlgebra
 
 export find_orbit4, find_orbit6
 
-function find_orbit4(accelerator::Accelerator; fixed_point_guess::Pos{Float64} = Pos(0.0), element_offset::Int=1)
+function find_orbit4(accelerator::Accelerator; fixed_point_guess::Pos{Float64} = Pos(0.0))
     delta = 1e-9              # [m],[rad],[dE/E]
     tolerance = 2.22044604925e-14
     max_nr_iters = 50
@@ -62,12 +62,12 @@ function find_orbit4(accelerator::Accelerator; fixed_point_guess::Pos{Float64} =
         return Pos{Float64}[], st_findorbit_not_converged
     end
     
-    closed_orbit, _, _ = line_pass(accelerator, co[7], "open", element_offset=element_offset)
+    closed_orbit, _, _ = line_pass(accelerator, co[7], "open")
     accelerator.radiation_state = radsts
     return closed_orbit, st_success
 end
 
-function find_orbit6(accelerator::Accelerator; fixed_point_guess::Pos{Float64} = Pos(0.0), element_offset::Int=1)
+function find_orbit6(accelerator::Accelerator; fixed_point_guess::Pos{Float64} = Pos(0.0))
 
     delta = 1e-9              # [m],[rad],[dE/E]
     tolerance = 2.22044604925e-14
@@ -83,7 +83,8 @@ function find_orbit6(accelerator::Accelerator; fixed_point_guess::Pos{Float64} =
     if isempty(cav_indices)
         return Pos[], st_no_cavities_found
     end
-    cav::Element = accelerator.lattice[cav_indices[1]]
+    cavidx::Int = cav_indices[1]
+    cav::Element = accelerator.lattice[cavidx]
 
     if true
         u0 = get_U0(accelerator)
@@ -92,12 +93,13 @@ function find_orbit6(accelerator::Accelerator; fixed_point_guess::Pos{Float64} =
     end
 
     frf::Float64 = cav.frequency
-    longitudinal_fixed_point::Float64 = (accelerator.velocity * accelerator.harmonic_number / frf) - accelerator.length
+    longitudinal_fixed_point::Float64 = (accelerator.velocity / 1e8 * accelerator.harmonic_number / frf * 1e8) - accelerator.length
 
     co::Vector{Pos{Float64}} = fill(fixed_point_guess, 7)
+    co2::Vector{Pos{Float64}} = fill(Pos(0.0), 7)
     D::Vector{Pos{Float64}} = fill(Pos(0.0), 7)
     M::Vector{Pos{Float64}} = fill(Pos(0.0), 6)
-    dco::Pos{Float64} = Pos(1.0, 1.0, 1.0, 1.0, 0.0, 0.0)
+    dco::Pos{Float64} = Pos(1.0)
     theta::Pos{Float64} = Pos(0.0)
     theta.dl = longitudinal_fixed_point
 
@@ -108,7 +110,6 @@ function find_orbit6(accelerator::Accelerator; fixed_point_guess::Pos{Float64} =
         co = co + D
         Ri = co[7]
         status = st_success
-        co2::Vector{Pos{Float64}} = fill(Pos(0.0), 7)
         for i in [1, 2, 3, 4, 5, 6, 7]
             pf, status, _ = line_pass(accelerator, co[i], [leng+1], turn_number=1)
             co2[i] = copy(pf[1])
@@ -128,7 +129,7 @@ function find_orbit6(accelerator::Accelerator; fixed_point_guess::Pos{Float64} =
         M_1 = fill(Pos(0.0), 6)
         matrix6_set_identity_posvec(M_1)
         M_1 = M_1 - M
-        dco = linalg_solve4_posvec(M_1, b)
+        dco = linalg_solve6_posvec(M_1, b)
         co[7] = dco + Ri
         co[1] = co[7]; co[2] = co[7]
         co[3] = co[7]; co[4] = co[7]
@@ -140,7 +141,7 @@ function find_orbit6(accelerator::Accelerator; fixed_point_guess::Pos{Float64} =
         return Pos{Float64}[], st_findorbit_not_converged
     end
     
-    closed_orbit, _, _ = line_pass(accelerator, co[7], "open", element_offset=element_offset)
+    closed_orbit, _, _ = line_pass(accelerator, co[7], "open")
     accelerator.radiation_state = radsts
     return closed_orbit, st_success
 end
@@ -176,9 +177,10 @@ function linalg_solve4_posvec(A::Vector{Pos{Float64}}, B::Pos{Float64})
 end
 
 function linalg_solve6_posvec(A::Vector{Pos{Float64}}, B::Pos{Float64})
-    m = Matrix{Float64}(undef, 6, 6)   # Create a 4x4 matrix
-    b = Vector{Float64}(undef, 6)      # Create a vector of size 4
-    x = Vector{Float64}(undef, 6)      # Create a solution vector of size 4
+    println(stdout, "using: linalg_solve6_posvec")
+    m = Matrix{Float64}(undef, 6, 6)   # Create a 6x6 matrix
+    b = Vector{Float64}(undef, 6)      # Create a vector of size 6
+    x = Vector{Float64}(undef, 6)      # Create a solution vector of size 6
     
     # Populate the matrix and vector
     for i in 1:6

--- a/src/modules/Tracking/PassMethods.jl
+++ b/src/modules/Tracking/PassMethods.jl
@@ -264,14 +264,13 @@ function pm_cavity_pass!(pos::Pos{Float64}, elem::Element, accelerator::Accelera
     philag::Float64 = elem.phase_lag
     frf::Float64 = elem.frequency
     harmonic_number::Int = accelerator.harmonic_number
-    velocity::Float64 = accelerator.velocity
-    # velocity = light_speed
+    velocity::Float64 = accelerator.velocity / 1e8 # numerical problem
     L0::Float64 = accelerator.length
-    T0::Float64 = L0 / velocity
-    #println(stdout,"\nfactor = ",harmonic_number/frf - T0)
+    factor::Float64 = (velocity*harmonic_number/frf*1e8 - L0) / velocity / 1e8
+    println(stdout,"\nfactor = ", factor)
 
     if elem.length == 0
-        pos.de += -nv * sin((TWOPI * frf * ((pos.dl/velocity) - ((harmonic_number/frf - T0)*turn_number))) - philag)
+        pos.de += -nv * sin((TWOPI * frf * ((pos.dl/velocity/1e8) - (factor*turn_number))) - philag)
         #pos.de += -nv * sin(TWOPI * frf * dl / velocity - philag)
     else
         px::Float64 = pos.px
@@ -285,7 +284,7 @@ function pm_cavity_pass!(pos::Pos{Float64}, elem::Element, accelerator::Accelera
         pos.dl += 0.5 * norml * pnorm * (px*px + py*py)
 
         # Longitudinal momentum kick
-        pos.de += -nv * sin((TWOPI * frf * ((pos.dl/velocity) - ((harmonic_number/frf - T0)*turn_number))) - philag)
+        pos.de += -nv * sin((TWOPI * frf * ((pos.dl/velocity/1e8) - (factor*turn_number))) - philag)
         # pos.de += -nv * sin(TWOPI * frf * dl / velocity - philag)
 
         # Drift half length

--- a/src/modules/Tracking/PassMethods.jl
+++ b/src/modules/Tracking/PassMethods.jl
@@ -267,7 +267,6 @@ function pm_cavity_pass!(pos::Pos{Float64}, elem::Element, accelerator::Accelera
     velocity::Float64 = accelerator.velocity / 1e8 # numerical problem
     L0::Float64 = accelerator.length
     factor::Float64 = (velocity*harmonic_number/frf*1e8 - L0) / velocity / 1e8
-    println(stdout,"\nfactor = ", factor)
 
     if elem.length == 0
         pos.de += -nv * sin((TWOPI * frf * ((pos.dl/velocity/1e8) - (factor*turn_number))) - philag)


### PR DESCRIPTION
Fix numeric error computation in cavity_pass: variable "factor" must be zero when frf = h/T0. This calc was returning factor ~ 10^-22, not zero.
Fix find_orbit6 calculation: copy and pointer problems. 
Fix linalg_solve6_posvec: passing wrong matrix to linear solver.